### PR TITLE
Using getter instead of manual code

### DIFF
--- a/src/main/java/org/design/patterns/Behavioral/ChainOfResponsibility/Models/Handler.java
+++ b/src/main/java/org/design/patterns/Behavioral/ChainOfResponsibility/Models/Handler.java
@@ -1,14 +1,13 @@
 package org.design.patterns.Behavioral.ChainOfResponsibility.Models;
 
+import lombok.Getter;
+
+@Getter
 public abstract class Handler {
     private Handler nextHandler;
 
     public Handler setNextHandler(final Handler nextHandler) {
         this.nextHandler = nextHandler;
-        return nextHandler;
-    }
-
-    public Handler getNextHandler() {
         return nextHandler;
     }
 


### PR DESCRIPTION
- Removed getNextHandler method
- Using getter to get the job done